### PR TITLE
Restore navigation links and secure login via MongoDB credentials

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -5,14 +5,14 @@ import { useRouter } from "next/navigation";
 
 export default function LoginPage() {
   const router = useRouter();
-  const [email, setEmail] = useState("");
+  const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const res = await signIn("credentials", {
-      email,
+      username,
       password,
       redirect: false,
     });
@@ -27,10 +27,10 @@ export default function LoginPage() {
     <form onSubmit={handleSubmit} className="max-w-sm mx-auto mt-24 space-y-4">
       {error && <p className="text-red-500">{error}</p>}
       <input
-        type="email"
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
+        type="text"
+        placeholder="Username"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
         className="w-full border p-2 rounded"
       />
       <input

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import ThemeToggle from "./ThemeToggle";
-import { Pencil } from "lucide-react";
+import { Pencil, FileText, User, Settings } from "lucide-react";
 import Link from "next/link";
 import { useSession, signOut } from "next-auth/react";
 
@@ -27,6 +27,15 @@ export default function Navbar() {
             <Pencil className="w-5 h-5" />
           </Link>
         )}
+        <Link href="/posts">
+          <FileText className="w-5 h-5" />
+        </Link>
+        <Link href="/profile">
+          <User className="w-5 h-5" />
+        </Link>
+        <Link href="/settings">
+          <Settings className="w-5 h-5" />
+        </Link>
         <ThemeToggle />
         {session ? (
           <button onClick={() => signOut()} className="text-sm">Logout</button>

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,7 +1,4 @@
 import Credentials from "next-auth/providers/credentials";
-import { connectDB } from "./utils";
-import User from "@/models/User";
-import bcrypt from "bcryptjs";
 import { NextAuthOptions } from "next-auth";
 
 export const authOptions: NextAuthOptions = {
@@ -10,19 +7,24 @@ export const authOptions: NextAuthOptions = {
     Credentials({
       name: "Credentials",
       credentials: {
-        email: { label: "Email", type: "text" },
-        password: { label: "Password", type: "password" }
+        username: { label: "Username", type: "text" },
+        password: { label: "Password", type: "password" },
       },
       async authorize(credentials) {
-        if (!credentials?.email || !credentials.password) return null;
-        await connectDB();
-        const user = await User.findOne({ email: credentials.email });
-        if (!user) return null;
-        const isValid = await bcrypt.compare(credentials.password, user.password);
-        if (!isValid) return null;
-        return { id: user._id.toString(), email: user.email };
-      }
-    })
+        const mongoUser = process.env.MONGODB_USERNAME;
+        const mongoPass = process.env.MONGODB_PASSWORD;
+        if (!mongoUser || !mongoPass) {
+          throw new Error("Missing MongoDB credentials");
+        }
+        if (
+          credentials?.username === mongoUser &&
+          credentials.password === mongoPass
+        ) {
+          return { id: "admin", name: mongoUser };
+        }
+        return null;
+      },
+    }),
   ],
-  pages: { signIn: "/login" }
+  pages: { signIn: "/login" },
 };


### PR DESCRIPTION
## Summary
- restore Posts, Profile, and Settings links to the navbar
- limit login to MongoDB user credentials via env variables
- switch login form to username/password

## Testing
- `MONGODB_URI="mongodb://localhost/test" MONGODB_USERNAME="user" MONGODB_PASSWORD="pass" npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6890d78c9a708324ab111e51b02c4384