### PR TITLE
Restrict login to fixed credentials

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -11,6 +11,14 @@ export default function LoginPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const allowedUser = "starman011";
+    const allowedPass = "dewmYw-5fotka-hokder";
+
+    if (username !== allowedUser || password !== allowedPass) {
+      setError("Invalid credentials");
+      return;
+    }
+
     const res = await signIn("credentials", {
       username,
       password,

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -11,16 +11,14 @@ export const authOptions: NextAuthOptions = {
         password: { label: "Password", type: "password" },
       },
       async authorize(credentials) {
-        const mongoUser = process.env.MONGODB_USERNAME;
-        const mongoPass = process.env.MONGODB_PASSWORD;
-        if (!mongoUser || !mongoPass) {
-          throw new Error("Missing MongoDB credentials");
-        }
+        const allowedUser = "starman011";
+        const allowedPass = "dewmYw-5fotka-hokder";
+
         if (
-          credentials?.username === mongoUser &&
-          credentials.password === mongoPass
+          credentials?.username === allowedUser &&
+          credentials.password === allowedPass
         ) {
-          return { id: "admin", name: mongoUser };
+          return { id: allowedUser, name: allowedUser };
         }
         return null;
       },


### PR DESCRIPTION
## Summary
- Allow only a single fixed username/password combination to authenticate
- Reject any other login attempts client-side and server-side

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890d9c9cc3883248bc776093ef52c7c