### PR TITLE
Add env-based MongoDB auth

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,6 +31,18 @@ A clean, developer-focused blog built from scratch using:
 | Icons     | Lucide                  |
 | Hosting   | Cloudflare Pages        |
 
+## 🔐 Environment Variables
+
+Create a `.env.local` file with the following values so the server can
+authenticate with MongoDB:
+
+```
+MONGODB_URI="<your-mongodb-host>"
+MONGODB_USERNAME="starman011"
+MONGODB_PASSWORD="<your-password>"
+MONGODB_DB="<database-name>"
+```
+
 ## 🗂️ Project Phases
 
 1. Project Setup

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,15 +1,13 @@
 // app/api/categories/route.ts
 import { NextResponse } from "next/server";
-import mongoose from "mongoose";
-import Post from "@/models/Post"; 
+import { connectDB } from "@/lib/utils";
+import Post from "@/models/Post";
 
 export const runtime = "nodejs";
 
 export async function GET() {
   try {
-    if (!mongoose.connections[0].readyState) {
-      await mongoose.connect(process.env.MONGODB_URI || "");
-    }
+    await connectDB();
 
     const result = await Post.aggregate([
       { $unwind: "$tags" },

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -12,12 +12,22 @@ let isConnected = false;
 export async function connectDB() {
   if (isConnected) return;
 
-  const mongooseUrl = process.env.MONGODB_URI;
+  const url = process.env.MONGODB_URI;
+  const username = process.env.MONGODB_USERNAME;
+  const password = process.env.MONGODB_PASSWORD;
+  const dbName = process.env.MONGODB_DB;
 
-  if (!mongooseUrl) {
+  if (!url) {
     throw new Error("MONGODB_URI is missing in .env.local");
   }
 
-  await mongoose.connect(mongooseUrl);
+  if (!username || !password) {
+    throw new Error("MongoDB credentials are missing in .env.local");
+  }
+
+  await mongoose.connect(url, {
+    auth: { username, password },
+    dbName,
+  });
   isConnected = true;
 }


### PR DESCRIPTION
## Summary
- support MongoDB username/password via environment variables
- use shared DB connector in categories API route
- document required MongoDB environment variables

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6890dbc46338832488b0321d73206cea